### PR TITLE
Release v1.0.6

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/data/consumer-rules.pro
+++ b/data/consumer-rules.pro
@@ -6,6 +6,8 @@
 -dontwarn io.netty.**
 -dontwarn com.typesafe.**
 -dontwarn org.slf4j.**
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
 # io.ktor -END
 
 # kotlinx-serialization - START


### PR DESCRIPTION
```
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /home/runner/work/AndroidAppTemplate/AndroidAppTemplate/app/build/outputs/mapping/productionRelease/missing_rules.txt.
ERROR: R8: Missing class java.lang.management.ManagementFactory (referenced from: java.lang.Boolean io.ktor.util.debug.IntellijIdeaDebugDetector$isDebuggerConnected$2.invoke())
Missing class java.lang.management.RuntimeMXBean (referenced from: java.lang.Boolean io.ktor.util.debug.IntellijIdeaDebugDetector$isDebuggerConnected$2.invoke())

```

のR8エラー対応